### PR TITLE
Disable deploy to old app service

### DIFF
--- a/.github/workflows/main_botshu-app-service.yml
+++ b/.github/workflows/main_botshu-app-service.yml
@@ -6,7 +6,7 @@ name: Build and deploy BotShu to production
 on:
   push:
     branches:
-      - main
+      - main-disable
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Keep the file for future reference for now but change the branch name to disable deploys to the previous app service.