### PR TITLE
Add initial heist calculator

### DIFF
--- a/lib/chat-handlers/handlers/public.js
+++ b/lib/chat-handlers/handlers/public.js
@@ -55,6 +55,48 @@ const publicHandlers = [
             );
         }
     },
+    // Initial heist calculator implementation using existing infra
+    function heistCalculator(p) {
+        if (
+            p.message.startsWith("!heistcalc") &&
+            p.words[1] !== undefined &&
+            p.words[2] !== undefined
+        ) {
+            // All parameters for !heistcalc are present
+            // i.e. the message is of the form `!heistcalc param1 param2`
+            // Heist calculator logic, move this to its own place later
+            const current = Number(p.words[1]);
+            const goal = Number(p.words[2]);
+            const earningsNeeded = goal - current;
+            const maxBalanceIfWin = current * 1.45;
+            const heistNeeded = earningsNeeded / 0.45;
+            if (goal <= current) {
+                p.client.say(
+                    p.channel,
+                    `Error: Goal must be higher than current balance Suskayge`
+                );
+                return;
+            }
+            if (goal > maxBalanceIfWin) {
+                p.client.say(
+                    p.channel,
+                    `Error: Goal is too high Sadge`
+                );
+            } else {
+                p.client.say(
+                    p.channel,
+                    `Use !heist ${Math.round(heistNeeded)}`
+                );
+            }
+        } else if (
+            p.message.startsWith("!heistcalc")
+        ) {
+            p.client.say(
+                p.channel,
+                `Type !heistcalc <your current number of points> <desired goal>`
+            );
+        }
+    },
 ];
 
 /**


### PR DESCRIPTION
Create a custom public command that allows users to calculate how much they need to heist in the **point heist mini-game** available in chat with the following syntax:

`!heistcalc <current number of points> <desired goal>`

Adds an initial implementation of the heist calculator to test usage and logic. In a future update, move this code to a module to encapsulate the logic in its own class.

Tested with:
- `!heistcalc 962664 1000000`
- `!heistcalc 962664 500000`
- `!heistcalc 962664 5000000`
- `!heistcalc 1000 1450`
- `!heistcalc 1000 1`

These could be unit test cases.