### PR TITLE
Update Mushu bot points calculator

### DIFF
--- a/lib/chat-handlers/handlers/public.js
+++ b/lib/chat-handlers/handlers/public.js
@@ -85,7 +85,7 @@ const publicHandlers = [
             } else {
                 p.client.say(
                     p.channel,
-                    `Use !heist ${Math.round(heistNeeded)}`
+                    `Use !heist ${Math.round(heistNeeded)} ${p.msg.userInfo.displayName}`
                 );
             }
         } else if (
@@ -93,7 +93,7 @@ const publicHandlers = [
         ) {
             p.client.say(
                 p.channel,
-                `Type !heistcalc <your current number of points> <desired goal>`
+                `Type !heistcalc <your current number of points> <desired goal> ${p.msg.userInfo.displayName}`
             );
         }
     },

--- a/lib/chat-handlers/handlers/public.js
+++ b/lib/chat-handlers/handlers/public.js
@@ -55,15 +55,15 @@ const publicHandlers = [
             );
         }
     },
-    // Initial heist calculator implementation using existing infra
-    function heistCalculator(p) {
+    // Initial Mushu bot points calculator implementation using existing infra
+    function pointsCalculator(p) {
         if (
-            p.message.startsWith("!heistcalc") &&
+            p.message.startsWith("!pointscalc") &&
             p.words[1] !== undefined &&
             p.words[2] !== undefined
         ) {
-            // All parameters for !heistcalc are present
-            // i.e. the message is of the form `!heistcalc param1 param2`
+            // All parameters for !pointscalc are present
+            // i.e. the message is of the form `!pointscalc param1 param2`
             // Heist calculator logic, move this to its own place later
             const current = Number(p.words[1]);
             const goal = Number(p.words[2]);
@@ -89,11 +89,11 @@ const publicHandlers = [
                 );
             }
         } else if (
-            p.message.startsWith("!heistcalc")
+            p.message.startsWith("!pointscalc")
         ) {
             p.client.say(
                 p.channel,
-                `Type !heistcalc <your current number of points> <desired goal> ${p.msg.userInfo.displayName}`
+                `Type !pointscalc <your current number of points> <desired goal> ${p.msg.userInfo.displayName}`
             );
         }
     },


### PR DESCRIPTION
- Rename `!heistcalc` to `!pointscalc` to be generic. Since the game name can change.
- Adds tags to make it clear who the bot is answering to.