### PR TITLE
Add message exempt logic

### DIFF
--- a/lib/language/language.js
+++ b/lib/language/language.js
@@ -21,6 +21,9 @@ async function handleMessageLanguage(p) {
 
     if (isUserExempt(p.msg.userInfo)) return;
 
+    // Ignore messages from the allowlist
+    if (isMessageExempt(p.message)) return;
+
     // Ignore commands
     if (p.message.startsWith("!")) return;
 
@@ -189,6 +192,15 @@ async function flagUser(p) {
 function isUserExempt(userInfo) {
     // Exempt if user is subscriber, mod or broadcaster.
     return userInfo.isSubscriber || userInfo.isMod || userInfo.isBroadcaster;
+}
+
+/**
+ * Check message against an allow list. If a match is made, don't continue processing.
+ * @returns True if message should be ignored for language detection.
+ */
+function isMessageExempt(message) {
+    const copypasta = /UN mexicat DOS mexicat TRES mexicat CUATRO/;
+    return copypasta.test(message);
 }
 
 /**


### PR DESCRIPTION
Add an initial implementation of an allow list to ignore messages that are not required to be processed by the language detection.